### PR TITLE
Use full URL for links

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,4 @@ enable_mathjax = false
 
 [MIT](LICENSE)
 
-Thanks to [Mathieu Mayer-Mazzoli](//github.com/mx3m) for creating this awesome theme!
+Thanks to [Mathieu Mayer-Mazzoli](https://github.com/mx3m) for creating this awesome theme!


### PR DESCRIPTION
So `zola check` does not complain about a missing base